### PR TITLE
Fix HTTP 504 errors and change return types

### DIFF
--- a/startupProject/src/main/java/com/startup/startupProject/Errorpage/ErrorPageController.java
+++ b/startupProject/src/main/java/com/startup/startupProject/Errorpage/ErrorPageController.java
@@ -1,0 +1,13 @@
+package com.startup.startupProject.Errorpage;
+
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class ErrorPageController implements ErrorController {
+    @GetMapping({"/", "/error"})
+    public String index() {
+        return "index.html";
+    }
+}

--- a/startupProject/src/main/java/com/startup/startupProject/Service/ETRIapiService.java
+++ b/startupProject/src/main/java/com/startup/startupProject/Service/ETRIapiService.java
@@ -62,11 +62,15 @@ public class ETRIapiService {
             con.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
             con.setRequestProperty("Authorization", accessKey);
 
+            con.setConnectTimeout(3000);
+            con.setReadTimeout(3000);
+
             DataOutputStream wr = new DataOutputStream(con.getOutputStream());
             wr.write(gson.toJson(request).getBytes(StandardCharsets.UTF_8));
             wr.flush();
             wr.close();
 
+            System.out.println("Please wait for a while.");
 
             responseCode = con.getResponseCode();
             InputStream is = con.getInputStream();
@@ -75,12 +79,11 @@ public class ETRIapiService {
             responBody = new String(buffer);
 
             System.out.println("[responseCode] " + responseCode);
-            System.out.println("[responBody]");
-            System.out.println(responBody);
+            System.out.println("[responBody] " + responBody);
 
             String[] list = responBody.split("score\":");
-            for (int i = 0; i < list.length; i++) {
-                System.out.println(list[i]);
+            for (String s : list) {
+                System.out.println(s);
             }
 
             String scoreString = list[1].substring(1, list[1].length() - 3);
@@ -90,11 +93,13 @@ public class ETRIapiService {
                 responseScore = Double.parseDouble(scoreString);
             } catch (NumberFormatException e) {
                 e.printStackTrace();
-                return 0.0;
+                responseScore = 0.0;
+                return responseScore;
             }
         } catch (IOException e) {
             e.printStackTrace();
-            return 0.0;
+            responseScore = 0.0;
+            return responseScore;
         }
         return responseScore;
     }

--- a/startupProject/src/main/java/com/startup/startupProject/upload/domain/Controller/UploadFileController.java
+++ b/startupProject/src/main/java/com/startup/startupProject/upload/domain/Controller/UploadFileController.java
@@ -45,9 +45,9 @@ public class UploadFileController {
         // 임시 데이터
         String objName = "안녕하세요 김인기입니다.";
 
-        Double score = etriapiService.etriApi(audioFileName, objName);
+        double score = etriapiService.etriApi(audioFileName, objName);
         score = Math.round(score*100)/100.0;
-        String scoreString = score.toString();
+        String scoreString = Double.toString(score);
 
         fileDeleteService.deleteFile(audioFileFullMame);
 


### PR DESCRIPTION
일부 적절치 않은 음성 녹음 또는 너무 짧은 녹음 시 504 Gateway Timeout 으로 인한 일정시간 대기시간이 필요했는데, 시간설정값(3초)을 줘서 해결하였으며, 기존의 0.0의 값을 반환하던 것을 점수값에 넣어서 점수를 반환하도록 코드 수정하였습니다.

그리고 
페이지 이동하면서 라우터를 통하지 않고 뒤로가기, 새로고침을 할 때 발생하는 Whitelabel Error Page 에러가 발생하는데, 
해결 방법으로 에러가 발생하는 경우 index.html 페이지를 리턴하도록 코드 추가했습니다.