### PR TITLE
Add DB connection settings & test files

### DIFF
--- a/startupProject/build.gradle
+++ b/startupProject/build.gradle
@@ -22,6 +22,10 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.springframework.boot:spring-boot-configuration-processor'
 
+
+	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.1.4'
+	runtimeOnly 'com.oracle.database.jdbc:ojdbc8'
+	testImplementation 'junit:junit:4.12'
 }
 
 tasks.named('test') {

--- a/startupProject/src/main/java/com/startup/startupProject/Errorpage/Controller/ErrorPageController.java
+++ b/startupProject/src/main/java/com/startup/startupProject/Errorpage/Controller/ErrorPageController.java
@@ -1,4 +1,4 @@
-package com.startup.startupProject.Errorpage;
+package com.startup.startupProject.Errorpage.Controller;
 
 import org.springframework.boot.web.servlet.error.ErrorController;
 import org.springframework.stereotype.Controller;

--- a/startupProject/src/main/java/com/startup/startupProject/StartupProjectApplication.java
+++ b/startupProject/src/main/java/com/startup/startupProject/StartupProjectApplication.java
@@ -1,18 +1,20 @@
 package com.startup.startupProject;
 
 import com.startup.startupProject.upload.property.FileUploadProperties;
+import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
+@MapperScan(value = {"com.startup.startupProject.data.mapper"})
 @SpringBootApplication
 @EnableConfigurationProperties({
-		FileUploadProperties.class
+        FileUploadProperties.class
 })
 public class StartupProjectApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(StartupProjectApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(StartupProjectApplication.class, args);
+    }
 
 }

--- a/startupProject/src/main/java/com/startup/startupProject/data/dto/daily.java
+++ b/startupProject/src/main/java/com/startup/startupProject/data/dto/daily.java
@@ -1,0 +1,11 @@
+package com.startup.startupProject.data.dto;
+
+import lombok.Data;
+import org.apache.ibatis.type.Alias;
+
+@Data
+@Alias("daily")
+public class daily {
+    private Long DAILYNO;
+    private String DSCRIPT;
+}

--- a/startupProject/src/main/java/com/startup/startupProject/data/mapper/ScriptMapper.java
+++ b/startupProject/src/main/java/com/startup/startupProject/data/mapper/ScriptMapper.java
@@ -1,0 +1,11 @@
+package com.startup.startupProject.data.mapper;
+
+import com.startup.startupProject.data.dto.daily;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface ScriptMapper {
+    List<daily> selectAllScript();
+}

--- a/startupProject/src/main/java/com/startup/startupProject/data/service/ScriptService.java
+++ b/startupProject/src/main/java/com/startup/startupProject/data/service/ScriptService.java
@@ -1,0 +1,22 @@
+package com.startup.startupProject.data.service;
+
+import com.startup.startupProject.data.dto.daily;
+import com.startup.startupProject.data.mapper.ScriptMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ScriptService implements ScriptMapper {
+
+    private final ScriptMapper scriptMapper;
+
+    @Override
+    public List<daily> selectAllScript() {
+        return scriptMapper.selectAllScript();
+    }
+}

--- a/startupProject/src/main/resources/application.properties
+++ b/startupProject/src/main/resources/application.properties
@@ -2,3 +2,19 @@ spring.servlet.multipart.max-file-size=1MB
 spring.servlet.multipart.max-request-size=10MB
 logging.level.org.apache.coyote.http11=debug
 file.upload-dir=./src/main/resources/audio
+
+# Oracle
+spring.datasource.driver-class-name=oracle.jdbc.driver.OracleDriver
+spring.datasource.url=jdbc:oracle:thin:@localhost:1521:xe
+spring.datasource.username=system
+spring.datasource.password=oracle
+
+# MyBatis
+# mapper.xml ?? ??
+mybatis.mapper-locations"=mapper/**/*.xml
+# model ???? camel case ??
+mybatis.configuration.map-underscore-to-camel-case=true
+# ??? ?? ??? ? ??? alias ??
+mybatis.type-aliases-package=com.startup.startupProject.data.dto
+# mapper ???? ??
+logging.level.com.example.demo.mapper.mapper=TRACE

--- a/startupProject/src/main/resources/mapper/ScriptMapper.xml
+++ b/startupProject/src/main/resources/mapper/ScriptMapper.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.startup.startupProject.data.mapper.ScriptMapper">
+
+    <select id="selectAllScript" resultType="daily">
+        SELECT dailyno, dscript from daily
+    </select>
+
+</mapper>

--- a/startupProject/src/test/java/com/startup/startupProject/data/mapper/ScriptMapperTest.java
+++ b/startupProject/src/test/java/com/startup/startupProject/data/mapper/ScriptMapperTest.java
@@ -1,0 +1,27 @@
+package com.startup.startupProject.data.mapper;
+
+import com.startup.startupProject.data.dto.daily;
+import com.startup.startupProject.data.service.ScriptService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.List;
+
+@SpringBootTest
+@RunWith(SpringRunner.class) // JUnit에 내장된 Runner 대신 이 클래스를 실행한다.
+public class ScriptMapperTest {
+
+    @Autowired
+    private ScriptService scriptService;
+
+    @Test
+    public void getAllScriptTest() {
+        List<daily> dailyList = scriptService.selectAllScript();
+        for (daily daily : dailyList) {
+            System.out.println(daily);
+        }
+    }
+}


### PR DESCRIPTION
1. DB연동에 필요한 build.gradle 의존성 추가 했습니다.
2. application.properties에 DB연동 관련 설정 추가했습니다.    (개인 설정에 맞게 id, pw 수정해서 사용하시면 됩니다.)
3.  db 연동 테스트를 위한 service, dao, testfile, xml파일 추가했습니다.
4. docker를 이용한 Oracle DB 11g 연동 방법은 아래에 적어두겠습니다.




Docker를 이용한 Oracle 11g 연동 방법

1. https://www.docker.com/   => docker 설치
2. docker pull jaspeen/oracle-xe-11g 를 통해 터미널에서 pull
3. Docker Container를 만들기 위해 
    docker run --name 붙이고싶은이름 -d -p 1521:1521 jaspeen/oracle-xe-11g
명령어를 통해 컨테이너 생성
4. 터미널에서 docker exec -it oracle sqlplus 명령어를 통해 DB에 로그인확인 ( 기존의 아이디 및 비밀번호는 system/oracle)
5. 차후 Docker는 DB관리 툴이기 때문에 DBMS 프로그램 설치
(본인은 https://dbeaver.io/download/ 이라는 DBeaver 프로그램을 설치해서 사용중)


확인 해보시고 에러 발생시 issue에 올려주시기 바랍니다.