### PR TITLE
Sand SelectedData to Server

### DIFF
--- a/startupProject/src/main/front_end/src/component/secondPage/DataView.tsx
+++ b/startupProject/src/main/front_end/src/component/secondPage/DataView.tsx
@@ -8,6 +8,7 @@ export default function DataView(props:{scClick:number[], ChangeScClick:any, dat
     const [hover, setHover] = useState(0);
     const [xclick, setxclick] = useState(0);
 
+
     const handleXicon = () => {
         const value = hover ? 0 : 1;
         setHover(value);
@@ -20,6 +21,14 @@ export default function DataView(props:{scClick:number[], ChangeScClick:any, dat
         }
         return style;
     }
+
+    function findeClickSc(e:number):boolean{
+        if(e === 1) return true;
+        return false;
+    }
+    // @ts-ignore
+    const selectedSc:string = props.data[props.scClick.findIndex(findeClickSc)].script;
+
     return(
         <div className='viewWrap'>
             <div className='view'>
@@ -27,7 +36,10 @@ export default function DataView(props:{scClick:number[], ChangeScClick:any, dat
                     <span className='x1' style={xStyle()}></span>
                     <span className='x2' style={xStyle()}></span>
                 </div>
-                <Recorder/>
+                <div className='scDataView'>
+                    {selectedSc}
+                </div>
+                <Recorder scClick={props.scClick} ChangeScClick={props.ChangeScClick} data={props.data} selectedSc={selectedSc}/>
             </div>
         </div>
     )

--- a/startupProject/src/main/front_end/src/component/secondPage/Recorder.tsx
+++ b/startupProject/src/main/front_end/src/component/secondPage/Recorder.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef } from 'react';
 import './Recorder.css';
 import WavEncoder from 'wav-encoder';
 
-function Recorder() {
+function Recorder(props:{scClick:number[], ChangeScClick:any, data:{ id?: number, script?: string }[], selectedSc:string}) {
   const [recording, setRecording] = useState<boolean>(false);
   const [audioURL, setAudioURL] = useState<string>('');
   const recorderRef = useRef<MediaRecorder | null>(null);
@@ -34,6 +34,7 @@ function Recorder() {
         setAudioURL(url);
         const formData = new FormData();
         formData.append('audio', wavBlob, 'recording.wav');
+        formData.append('script', props.selectedSc );
         fetch('/upload', { method: 'POST', body: formData });
       });
 

--- a/startupProject/src/main/front_end/src/component/secondPage/SubDataList.tsx
+++ b/startupProject/src/main/front_end/src/component/secondPage/SubDataList.tsx
@@ -43,8 +43,12 @@ export default function SubDataList(props:{click:number[], ChangeClick:any, data
     };
 
     const viewData = (idx:number) => {
-        scClick.fill(0);
         scClick[idx] = 1;
+        for(let i=0; i<scClick.length; i++){
+            if(i !== idx){
+                scClick[i] = 0;
+            }
+        }
         setScClick([...scClick]);
     }
 


### PR DESCRIPTION
1. 클릭된 스크립트를 포함하는 부모 객체 SubDataList 컴포넌트부터 props를 전달하여 Recorder 컴포넌트까지 도달하도록 수정했습니다.
2. 선택된 스크립트가 view에 보이도록 코드를 추가했습니다.
3. 서버로 녹음 파일을 보낼 때 해당 스크립트도 포함하여 전달하도록 수정했습니다.